### PR TITLE
qualify command 'i' value before setting node id

### DIFF
--- a/firmware/RFM69CW_RF_Demo_ATmega328/RFM69CW_RF12_Demo_ATmega328/RFM69CW_RF12_Demo_ATmega328.ino
+++ b/firmware/RFM69CW_RF_Demo_ATmega328/RFM69CW_RF12_Demo_ATmega328/RFM69CW_RF12_Demo_ATmega328.ino
@@ -387,8 +387,10 @@ static void handleInput (char c) {
     switch (c) {
 
     case 'i': // set node id
-      config.nodeId = (config.nodeId & 0xE0) + (value & 0x1F);
-      saveConfig();
+      if ((value > 0) && (value < 31)) {
+        config.nodeId = (config.nodeId & 0xE0) + (value & 0x1F);
+        saveConfig();
+        }
       break;
 
     case 'b': // set band: 4 = 433, 8 = 868, 9 = 915


### PR DESCRIPTION
A stray "i" can attempt to set a node id of "0" and result in a "config save failed" although setting the node id to "0" will of succeeded and the result is no further packets will be processed until a valid node id is set.